### PR TITLE
Add numpydoc for rtd

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pytest>=3.2.1
 nbval>=0.9.0
 pytest-cov>=2.5.1
 flake8>=3.5.0
+numpydoc
 


### PR DESCRIPTION
This is the only change needed to auto-build the docs on RTD. On RTD under "Advanced Settings" I also pointed it at the requirements file and set the interpreter to CPython3.X (did this before checking they were needed, so they might not be) and the resulting docs are at https://pyro2-rtd-fork.readthedocs.io/en/rtd/ .

This addresses issue #37 which may link to issue #38 .